### PR TITLE
Integrate Travis CI, add build status to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+os:
+  - linux
+
+go:
+- 1.11.x
+
+git:
+  depth: 1
+
+# Dependencies included in vendor
+install: true
+
+script:
+  - go test
+
+
+# Leave out email notifications.
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/mutating-trace-admission-controller)](https://goreportcard.com/report/sigs.k8s.io/mutating-trace-admission-controller)
+[![Build Status](https://travis-ci.org/kubernetes-sigs/mutating-trace-admission-controller.svg?branch=master)](https://travis-ci.org/kubernetes-sigs/mutating-trace-admission-controller)
+
 # Mutating trace admission controller
 
 [Mutating admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) that injects base64 encoded [OpenCensus span context](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Span.md#spancontext) into the `trace.kubernetes.io/context` object annotation.
@@ -26,3 +29,4 @@ There are example patches which can be used with `kustomize` to configure the de
 `kustomize build deploy/overlays/example | kubectl apply -f -`
 
 This can be used, for example, to set different sampling policies between production and staging clusters.
+


### PR DESCRIPTION
This change introduces Travis configuration that runs `go test` on each new PR. The latest build status for `go test` on the master branch should appear in the README once Travis is activated for this repo within `kubernetes-sigs`.

Include the Go Report Card status in the README as well.